### PR TITLE
Fix the version display error of gptransfer

### DIFF
--- a/gpMgmt/Makefile
+++ b/gpMgmt/Makefile
@@ -27,6 +27,7 @@ SET_VERSION_SCRIPTS = \
 	bin/gpstop \
 	bin/gpsys1 \
 	bin/gpcheckcat \
+	bin/gptransfer \
 	sbin/gpaddconfig.py \
 	sbin/gpchangeuserpassword \
 	sbin/gpcleansegmentdir.py \


### PR DESCRIPTION
gptransfer version shows an error because there is no replacement at compile time.

[gp6@node ~]$ gptransfer --version
gptransfer version $Revision: #1 $

right:
[gp6@node ~]$ gpstart --version
gpstart version 6.0.0 alpha.0+dev.7519.g6d629f7 build dev oss
[gp6@node ~]$ gpstop --version
gpstop version 6.0.0 alpha.0+dev.7519.g6d629f7 build dev oss