### PR TITLE
Remove the extra blank lines in commands log

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -236,7 +236,7 @@ CHK_PARAMS () {
 		    $TR -d '\r' < $CLUSTER_CONFIG > $TMP_FILE
 		    $MV $TMP_FILE $CLUSTER_CONFIG
 		    LOG_MSG "[INFO]:-Dumping $CLUSTER_CONFIG to logfile for reference"
-		    $CAT $CLUSTER_CONFIG|$GREP -v "^#" >> $LOG_FILE
+		    $CAT $CLUSTER_CONFIG|$GREP -v "^#" |$GREP -v "^$" >> $LOG_FILE
 		    LOG_MSG "[INFO]:-Completed $CLUSTER_CONFIG dump to logfile"
 		    # Source the cluster configuration file
 		    LOG_MSG "[INFO]:-Reading Greenplum configuration file $CLUSTER_CONFIG" 1
@@ -1714,7 +1714,7 @@ READ_INPUT_CONFIG () {
     $TR -d '\r' < $INPUT_CONFIG > $TMP_FILE
     $MV $TMP_FILE $INPUT_CONFIG
     LOG_MSG "[INFO]:-Dumping $INPUT_CONFIG to logfile for reference"
-    $CAT $INPUT_CONFIG|$GREP -v "^#" >> $LOG_FILE
+    $CAT $INPUT_CONFIG|$GREP -v "^#" |$GREP -v "^$" >> $LOG_FILE
     LOG_MSG "[INFO]:-Completed $INPUT_CONFIG dump to logfile"
     # Source the cluster configuration file
     LOG_MSG "[INFO]:-Reading Greenplum configuration file $INPUT_CONFIG"


### PR DESCRIPTION
There are a lot of blank lines in the 'gpinitsystem' log. These are read directly from the configuration file using commands 'cat'. The comments are turned into blank lines, but they are not removed.

gpinitsystem log:
gpinitsystem:node:gp6-[INFO]:-Start Main
gpinitsystem:node:gp6-[INFO]:-Command line options passed to utility = -c ../gpinitsystem_config
gpinitsystem:node:gp6-[INFO]:-Start Function CHK_GPDB_ID
gpinitsystem:node:gp6-[INFO]:-Current user id of gp6, matches initdb id of gp6
gpinitsystem:node:gp6-[INFO]:-End Function CHK_GPDB_ID
gpinitsystem:node:gp6-[INFO]:-Start Function CHK_PARAMS
gpinitsystem:node:gp6-[INFO]:-Checking configuration parameters, please wait...
gpinitsystem:node:gp6-[INFO]:-Start Function CHK_FILE
gpinitsystem:node:gp6-[INFO]:-Checking file ../gpinitsystem_config
gpinitsystem:node:gp6-[INFO]:-End Function CHK_FILE
gpinitsystem:node:gp6-[INFO]:-Dumping gpinitsystem_config to logfile for reference



ARRAY_NAME="EMC Greenplum DW"

SEG_PREFIX=gpseg

PORT_BASE=40300

declare -a DATA_DIRECTORY=(/data1/gp6/primary /data1/gp6/primary)

MASTER_HOSTNAME=node

MASTER_DIRECTORY=/data1/gp6/master

MASTER_PORT=6435

TRUSTED_SHELL=ssh

CHECK_POINT_SEGMENTS=8

ENCODING=UNICODE


MIRROR_PORT_BASE=50300

REPLICATION_PORT_BASE=41300

MIRROR_REPLICATION_PORT_BASE=51300

declare -a MIRROR_DATA_DIRECTORY=(/data1/gp6/mirror /data1/gp6/mirror)




MACHINE_LIST_FILE=/home/gp6/seg_all
gpinitsystem:node:gp6-[INFO]:-Completed ../gpinitsystem_config dump to logfile
...
gpinitsystem:node:gp6-[INFO]:-Dump current system locale to log file
LANG=en_US.UTF-8
LC_CTYPE="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_PAPER="en_US.UTF-8"
LC_NAME="en_US.UTF-8"
LC_ADDRESS="en_US.UTF-8"
LC_TELEPHONE="en_US.UTF-8"
LC_MEASUREMENT="en_US.UTF-8"
LC_IDENTIFICATION="en_US.UTF-8"
LC_ALL=
gpinitsystem:node:gp6-[INFO]:-End of system locale dump
...


Modified log:

gpinitsystem:node:gp6-[INFO]:-Start Main
...
gpinitsystem:node:gp6-[INFO]:-Dumping ../gpinitsystem_config to logfile for reference
ARRAY_NAME="EMC Greenplum DW"
SEG_PREFIX=gpseg
PORT_BASE=40300
declare -a DATA_DIRECTORY=(/data1/gp6/primary /data1/gp6/primary)
MASTER_HOSTNAME=node
MASTER_DIRECTORY=/data1/gp6/master
MASTER_PORT=6435
TRUSTED_SHELL=ssh
CHECK_POINT_SEGMENTS=8
ENCODING=UNICODE
MIRROR_PORT_BASE=50300
REPLICATION_PORT_BASE=41300
MIRROR_REPLICATION_PORT_BASE=51300
declare -a MIRROR_DATA_DIRECTORY=(/data1/gp6/mirror /data1/gp6/mirror)
MACHINE_LIST_FILE=/home/gp6/seg_all
gpinitsystem:node:gp6-[INFO]:-Completed ../gpinitsystem_config dump to logfile
...